### PR TITLE
fix: firebase deployステップにOAuthアクセストークンを渡すよう修正

### DIFF
--- a/.github/workflows/sample_firebase.yml
+++ b/.github/workflows/sample_firebase.yml
@@ -30,7 +30,9 @@ jobs:
       - uses: pnpm/action-setup@v4
 
       - uses: google-github-actions/auth@v2
+        id: auth
         with:
+          token_format: 'access_token'
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
@@ -47,4 +49,6 @@ jobs:
         run: ${{ env.ACTIONS_BUILD_COMMAND }}
 
       - name: firebase deploy
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: pnpm exec firebase deploy --only hosting


### PR DESCRIPTION
token_format: 'access_token' を指定してアクセストークンを生成し、
GOOGLE_OAUTH_ACCESS_TOKEN 環境変数経由で firebase tools に渡す。

https://claude.ai/code/session_01GxHY8LJjp5vA9yRG6tT3Bo