### PR TITLE
Migrate to Next.js App Router and document monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 使用言語 / フレームワーク / ライブラリ
 
-- Framework: [Next.js](https://nextjs.org/) (Pages Router)
+- Framework: [Next.js](https://nextjs.org/) (App Router)
 - View: [React](https://react.dev/) 19
 - State Management: [Zustand](https://zustand-demo.pmnd.rs/)
 - AltJS: [TypeScript](https://www.typescriptlang.org/) 6
@@ -10,7 +10,14 @@
 - Linter: [ESLint](https://eslint.org/) 9 (flat config)
 - Formatter: [Prettier](https://prettier.io/)
 - Test: [Jest](https://jestjs.io/) + [Testing Library](https://testing-library.com/)
-- Package Manager: [pnpm](https://pnpm.io/)
+- Package Manager: [pnpm](https://pnpm.io/) (workspace)
+
+## 構成
+
+モノレポ構成。`packages/` 以下に以下のパッケージが存在します。
+
+- `packages/web` — Next.js アプリ本体
+- `packages/core` — 共有型・純粋ユーティリティ
 
 ## 開発手順
 


### PR DESCRIPTION
## Summary
Updated project documentation to reflect the migration from Next.js Pages Router to App Router and introduced a monorepo workspace structure using pnpm.

## Key Changes
- **Framework upgrade**: Updated Next.js routing from Pages Router to App Router
- **Monorepo structure**: Documented the new workspace-based organization with separate packages:
  - `packages/web` — Next.js application
  - `packages/core` — Shared types and utility functions
- **Package manager**: Clarified pnpm usage with workspace support
- **Documentation**: Added new "構成 (Structure)" section explaining the monorepo layout

## Details
The changes reflect an architectural shift to a monorepo pattern that enables better code organization and reusability across packages. The App Router migration aligns with modern Next.js best practices for improved performance and developer experience.

https://claude.ai/code/session_01PEakZ3e5frJRSaLwQX25z6